### PR TITLE
Added Color HEX code with # removed and 'cp-' prepended as a CSS Class for each option

### DIFF
--- a/jquery.simplecolorpicker.js
+++ b/jquery.simplecolorpicker.js
@@ -56,10 +56,12 @@
       }
 
       // Build the list of colors
-      // <span class="color selected" title="Green" style="background-color: #7bd148;" role="button"></span>
+      // Color HEX code is added to CSS Classes with # removed and 'cp-' prepended
+      // <span class="color cp-ffffff selected" title="Green" style="background-color: #7bd148;" role="button"></span>
       self.$select.find('> option').each(function() {
         var $option = $(this);
         var color = $option.val();
+        var colorCssClass = 'cp-' + color.substring(1);
 
         var isSelected = $option.is(':selected');
         var isDisabled = $option.is(':disabled');
@@ -84,7 +86,7 @@
           role = ' role="button" tabindex="0"';
         }
 
-        var $colorSpan = $('<span class="color"'
+        var $colorSpan = $('<span class="color ' + colorCssClass + '"'
                          + title
                          + ' style="background-color: ' + color + ';"'
                          + ' data-color="' + color + '"'


### PR DESCRIPTION
This allows you to easily target any color selection option with CSS.  When I used the color `White` `#ffffff` you could not see the option with no border set.  Further there was no easy way to target the White selection option!  Now I can easily target the color White with my CSS to add a border!

Example output of color options generated with this modification...

`<span class="color cp-ffffff selected" title="Green" style="background-color: #7bd148;" role="button"></span>`