### PR TITLE
Added selectColorOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,16 @@ $('select[name="colorpicker"]').simplecolorpicker({
 - theme: font to use for the ok/check mark (default: `''`), available themes: [`regularfont`](https://github.com/tkrotoff/jquery-simplecolorpicker/blob/master/jquery.simplecolorpicker-regularfont.css), [`fontawesome`](https://github.com/tkrotoff/jquery-simplecolorpicker/blob/master/jquery.simplecolorpicker-fontawesome.css), [`glyphicons`](https://github.com/tkrotoff/jquery-simplecolorpicker/blob/master/jquery.simplecolorpicker-glyphicons.css)
 - picker: show the colors inside a picker instead of inline (default: `false`)
 - pickerDelay: show and hide animation delay in milliseconds (default: `0`)
-
+- 
+#### Added selectColor option
+Now y
+```JavaScript
+$('select[name="colorpicker"]')
+  .simplecolorpicker({ theme: 'glyphicons', selectColor: '#e1e1e1' })
+  .on('change', function() {
+    $(document.body).css('background-color', $('select[name="colorpicker"]').val());
+  });
+```
 ## Browser support
 
 Simplecolorpicker supports all modern browsers starting with Internet Explorer 8 included.

--- a/README.md
+++ b/README.md
@@ -62,10 +62,9 @@ $('select[name="colorpicker"]').simplecolorpicker({
 - theme: font to use for the ok/check mark (default: `''`), available themes: [`regularfont`](https://github.com/tkrotoff/jquery-simplecolorpicker/blob/master/jquery.simplecolorpicker-regularfont.css), [`fontawesome`](https://github.com/tkrotoff/jquery-simplecolorpicker/blob/master/jquery.simplecolorpicker-fontawesome.css), [`glyphicons`](https://github.com/tkrotoff/jquery-simplecolorpicker/blob/master/jquery.simplecolorpicker-glyphicons.css)
 - picker: show the colors inside a picker instead of inline (default: `false`)
 - pickerDelay: show and hide animation delay in milliseconds (default: `0`)
-- 
 
 #### Added selectColor option
-Now is possible to use selectColor with other options:
+Now is possible to use **selectColor** with other options:
 
 ```JavaScript
 $('select[name="colorpicker"]')

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ $('select[name="colorpicker"]').simplecolorpicker({
 - picker: show the colors inside a picker instead of inline (default: `false`)
 - pickerDelay: show and hide animation delay in milliseconds (default: `0`)
 - 
+
 #### Added selectColor option
-Now y
+Now is possible to use selectColor with other options:
+
 ```JavaScript
 $('select[name="colorpicker"]')
   .simplecolorpicker({ theme: 'glyphicons', selectColor: '#e1e1e1' })
@@ -72,6 +74,7 @@ $('select[name="colorpicker"]')
     $(document.body).css('background-color', $('select[name="colorpicker"]').val());
   });
 ```
+
 ## Browser support
 
 Simplecolorpicker supports all modern browsers starting with Internet Explorer 8 included.

--- a/jquery.simplecolorpicker.js
+++ b/jquery.simplecolorpicker.js
@@ -212,6 +212,11 @@
       if (data === undefined) {
         $this.data('simplecolorpicker', (data = new SimpleColorPicker(this, options)));
       }
+      /* Added selectColor option with other options */
+      if (option.selectColor) {
+          args.push(option.selectColor);
+          option = 'selectColor';
+      }
       if (typeof option === 'string') {
         data[option].apply(data, args);
       }


### PR DESCRIPTION
Hi 
I have added a small mod to use selectColor inside option block, in this way is possible to use both
selectColor and other options:
```JavaScript
	$('select[name="colorpicker"]')
	 .simplecolorpicker({ theme: 'glyphicons', selectColor: '#e1e1e1' })
	 .on('change', function() {
	 $(document.body).css('background-color', $('select[name="colorpicker"]').val());
	 });
```