### PR TITLE
Position of colopicker is not correct with some jQuery versions

### DIFF
--- a/jquery.simplecolorpicker.js
+++ b/jquery.simplecolorpicker.js
@@ -125,10 +125,16 @@
 
     showPicker: function() {
       var pos = this.$icon.offset();
+      var iconOutH = 0;
+      if (typeof this.$icon.outerHeight() === 'object'){
+        iconOutH = this.$icon.outerHeight(true);
+      } else {
+        iconOutH = this.$icon.outerHeight();
+      }
       this.$picker.css({
         // Remove some pixels to align the picker icon with the icons inside the dropdown
         left: pos.left - 6,
-        top: pos.top + this.$icon.outerHeight()
+        top: pos.top + iconOutH
       });
 
       this.$picker.show(this.options.pickerDelay);


### PR DESCRIPTION
In some jquery versions [outerheight](http://api.jquery.com/outerheight/) method returns object instead of height and position of colorpicker is computed wrong.

More info is [here](https://bugs.jquery.com/ticket/12159) and [here](http://stackoverflow.com/questions/12093806/jquery-1-8-outer-height-width-not-working)

